### PR TITLE
Implicit bond parsing fix.

### DIFF
--- a/src/Data/SMARTS.hs
+++ b/src/Data/SMARTS.hs
@@ -16,6 +16,7 @@ module Data.SMARTS (SMARTS (..),
                     Negation (..),
                     Chirality (..),
                     PrimitiveAtom (..),
+                    RingClosure (..),
                     parseSmarts,
                     smartsP,
                     writeSmarts) where

--- a/src/Data/SMARTS/Internal/Parser.hs
+++ b/src/Data/SMARTS/Internal/Parser.hs
@@ -115,15 +115,15 @@ anyBondP = do
 -- *** Specific atom parser
 
 specificAtomP :: Parser SpecificAtom
-specificAtomP = (Primitive <$> primitiveAtomP <*> many cycleP) <|> descriptionP
+specificAtomP = (Primitive <$> primitiveAtomP <*> many closureP) <|> descriptionP
 
 descriptionP :: Parser SpecificAtom
 descriptionP = do
   _ <- char '['
   expr <- atomExpressionP
   _ <- char ']'
-  cycleIdx <- many cycleP
-  return (Description expr cycleIdx)
+  closures <- many closureP
+  return (Description expr closures)
 
 -- *** Boolean expressions on Specifications
 
@@ -285,15 +285,16 @@ negationP = do
 int :: Parser Int
 int = fromIntegral <$> integer
 
-cycleP :: Parser Int
-cycleP = do
+closureP :: Parser RingClosure
+closureP = try $ do
+  bond <- bondExpressionP
   dd <- optional (char '%')
   c1 <- digitChar
   case dd of
-    Nothing -> return (read [c1])
+    Nothing -> return $ Closure bond (read [c1])
     Just _  -> do
       c2 <- digitChar
-      return (read [c1, c2])
+      return $ Closure bond (read [c1, c2])
 
 allAtoms :: [String]
 allAtoms =["Zr","Zn","Yb","Y","Xe","W","V","U","Tm","Tl",

--- a/src/Data/SMARTS/Internal/Parser.hs
+++ b/src/Data/SMARTS/Internal/Parser.hs
@@ -60,9 +60,9 @@ bondP = doubleP <|>
         singleP
 
 singleP :: Parser Bond
-singleP = try $ do
+singleP = do
   neg <- negationP
-  _ <- char '-'
+  _ <- try $ char '-'
   return (Single neg)
 
 doubleP :: Parser Bond

--- a/src/Data/SMARTS/Internal/Parser.hs
+++ b/src/Data/SMARTS/Internal/Parser.hs
@@ -7,6 +7,7 @@ import           Data.Text                  (pack)
 import           Text.Megaparsec
 import           Text.Megaparsec.Lexer
 import           Text.Megaparsec.Text
+import Control.Monad(when, void)
 
 smartsP :: Parser SMARTS
 smartsP = do
@@ -62,7 +63,9 @@ bondP = doubleP <|>
 singleP :: Parser Bond
 singleP = do
   neg <- negationP
-  _ <- try $ char '-'
+  case neg of
+    Pass -> try $ char '-'
+    _    -> char '-'
   return (Single neg)
 
 doubleP :: Parser Bond

--- a/src/Data/SMARTS/Internal/Types.hs
+++ b/src/Data/SMARTS/Internal/Types.hs
@@ -122,11 +122,11 @@ data Bond = Single Negation
           | Down Negation Presence
           | Ring Negation
           | AnyBond Negation
+          | Implicit
   deriving (Eq, Ord)
 
 instance Show Bond where
-  show (Single Negate)     = "!-"
-  show (Single Pass)       = ""
+  show (Single neg)        = show neg ++ "-"
   show (Double neg)        = show neg ++ "="
   show (Triple neg)        = show neg ++ "#"
   show (Aromatic neg)      = show neg ++ ":"
@@ -134,6 +134,7 @@ instance Show Bond where
   show (Down neg presence) = show neg ++ ('\\' : show presence)
   show (Ring neg)          = show neg ++ "@"
   show (AnyBond neg)       = show neg ++ "~"
+  show Implicit            = ""
 
 newtype BondImplicitAnd = BondImplicitAnd [Bond]
   deriving (Eq, Ord)

--- a/src/Data/SMARTS/Internal/Types.hs
+++ b/src/Data/SMARTS/Internal/Types.hs
@@ -17,12 +17,20 @@ fancyId :: Int -> String
 fancyId n | n <= 9 = show n
           | otherwise = '%':show n
 
-data SpecificAtom = Primitive PrimitiveAtom [Int] | Description AtomExpression [Int]
+
+data RingClosure = Closure BondExpression Int
+  deriving (Eq, Ord)
+
+instance Show RingClosure where
+  show (Closure bond idx) = show bond ++ fancyId idx
+
+
+data SpecificAtom = Primitive PrimitiveAtom [RingClosure] | Description AtomExpression [RingClosure]
   deriving (Eq, Ord)
 
 instance Show SpecificAtom where
-  show (Primitive prim idx)   = show prim ++ concatMap fancyId idx
-  show (Description expr idx) = concat ["[", show expr, "]", concatMap fancyId idx]
+  show (Primitive prim idx)   = show prim ++ concatMap show idx
+  show (Description expr idx) = concat ["[", show expr, "]", concatMap show idx]
 
 
 newtype AtomImplicitAnd = AtomImplicitAnd [Specification]

--- a/test/Smarts.hs
+++ b/test/Smarts.hs
@@ -68,6 +68,12 @@ innerStructureTests = describe "SMARTS is parsed correctly." $ do
   it "C[Na]=F" $ parseSmarts "C[Na]=F" `shouldBe` Just (SMARTS [Linear $ Component [(implBond, Primitive (Atom "C") []),
                                                                                     (implBond, Description explNa []),
                                                                                     (doubleBond, Primitive (Atom "F") [])]])
+  it "C1C=CC=CC=1" $ parseSmarts "C1C=CC=CC=1" `shouldBe` Just (SMARTS [Linear $ Component [(implBond, Primitive (Atom "C") [Closure implBond 1]),
+                                                                                            (implBond, Primitive (Atom "C") []),
+                                                                                            (doubleBond, Primitive (Atom "C") []),
+                                                                                            (implBond, Primitive (Atom "C") []),
+                                                                                            (doubleBond, Primitive (Atom "C") []),
+                                                                                            (implBond, Primitive (Atom "C") [Closure doubleBond 1])]])
 
 basicTests :: Spec
 basicTests = describe "Simple syntax constructions." $ do
@@ -220,7 +226,6 @@ invalidSyntaxTests = describe "Parser should fail on these." $ do
   invalidSyntax "CC(CCCC(C)C)C1CCC2C1(CCC3C2CC=C4C3(CCC(C4-)O)C)C"
   invalidSyntax "O[C@@H]1[C@@H](O)[C@@H](OC(O)[C@H]]1O)CO"
   invalidSyntax "C(=C)(C(=C)C(C)C"
-  invalidSyntax "CCCN#2CCC"
   invalidSyntax "O=C(O)Cc2c1ccccdc1nc2"
-  invalidSyntax "c12c(cccc1)CN(C([C@H](c1cn(C)nc1)NC)=O)Cc1ccccc1-2"
+  invalidSyntax "c12c(cccc1)CN(C([C@H](c1cn(C)nc1)NC)=O)Cc1ccccc1-2-"
   invalidSyntax "C!C"

--- a/test/Smarts.hs
+++ b/test/Smarts.hs
@@ -191,3 +191,4 @@ invalidSyntaxTests = describe "Parser should fail on these." $ do
   invalidSyntax "CCCN#2CCC"
   invalidSyntax "O=C(O)Cc2c1ccccdc1nc2"
   invalidSyntax "c12c(cccc1)CN(C([C@H](c1cn(C)nc1)NC)=O)Cc1ccccc1-2"
+  invalidSyntax "C!C"

--- a/test/Smarts.hs
+++ b/test/Smarts.hs
@@ -9,6 +9,7 @@ import           Text.Megaparsec
 
 main :: IO ()
 main = hspec $ do
+  innerStructureTests
   basicTests
   specificAtomTests
   stolenFromSmilesTests
@@ -36,6 +37,37 @@ smartsCmp (_:_) [] = False
 smartsCmp (x:xs) (y:ys) | x == y = smartsCmp xs ys
                         | (x == '1') || (x == '-') = smartsCmp xs (y:ys)
                         | otherwise = False
+
+singleBond :: BondExpression
+singleBond = BondExpression [BondOr [BondExplicitAnd [BondImplicitAnd [Single Pass]]]]
+
+implBond :: BondExpression
+implBond = BondExpression [BondOr [BondExplicitAnd [BondImplicitAnd [Implicit]]]]
+
+notSingleBond :: BondExpression
+notSingleBond = BondExpression [BondOr [BondExplicitAnd [BondImplicitAnd [Single Negate]]]]
+
+doubleBond :: BondExpression
+doubleBond = BondExpression [BondOr [BondExplicitAnd [BondImplicitAnd [Double Pass]]]]
+
+explNa :: AtomExpression
+explNa = AtomExpression [AtomOr [AtomExplicitAnd [AtomImplicitAnd [Explicit Pass $ Atom "Na"]]]]
+
+innerStructureTests :: Spec
+innerStructureTests = describe "SMARTS is parsed correctly." $ do
+  it "C" $ parseSmarts "C" `shouldBe` Just (SMARTS [Linear $ Component [(implBond, Primitive (Atom "C") [])]])
+  it "CC" $ parseSmarts "CC" `shouldBe` Just (SMARTS [Linear $ Component [(implBond, Primitive (Atom "C") []), (implBond, Primitive (Atom "C") [])]])
+  it "CN!-a=F" $ parseSmarts "CN!-a=F" `shouldBe` Just (SMARTS [Linear $ Component [(implBond, Primitive (Atom "C") []),
+                                                                                    (implBond, Primitive (Atom "N") []),
+                                                                                    (notSingleBond, Primitive AnyAromatic []),
+                                                                                    (doubleBond, Primitive (Atom "F") [])]])
+  it "CNa=F" $ parseSmarts "CNa=F" `shouldBe` Just (SMARTS [Linear $ Component [(implBond, Primitive (Atom "C") []),
+                                                                                (implBond, Primitive (Atom "N") []),
+                                                                                (implBond, Primitive AnyAromatic []),
+                                                                                (doubleBond, Primitive (Atom "F") [])]])
+  it "C[Na]=F" $ parseSmarts "C[Na]=F" `shouldBe` Just (SMARTS [Linear $ Component [(implBond, Primitive (Atom "C") []),
+                                                                                    (implBond, Description explNa []),
+                                                                                    (doubleBond, Primitive (Atom "F") [])]])
 
 basicTests :: Spec
 basicTests = describe "Simple syntax constructions." $ do


### PR DESCRIPTION
Implicit bond may be either single or aromatic depending on between which atoms it lies. So its type is no more assigned during the parsing.