### PR TITLE
New LTS, Aryl groups.

### DIFF
--- a/smiles.cabal
+++ b/smiles.cabal
@@ -24,6 +24,7 @@ library
                      , Data.SMILES
                      , Data.SMILES.Parser
                      , Data.SMILES.Writer
+                     , Data.SMILES.ParserTypes
 
                      -- SMARTS
 

--- a/src/Data/SMARTS/Internal/Parser.hs
+++ b/src/Data/SMARTS/Internal/Parser.hs
@@ -143,7 +143,9 @@ atomExpressionP = AtomExpression <$> atomOrP `sepBy` char ';'
 -- *** Specification parser
 
 specificationP :: Parser Specification
-specificationP = explicitP <|>
+specificationP = arylGroupP <|>
+                 heteroarylGroupP <|>
+                 explicitP <|>
                  degreeP <|>
                  attachedHP <|>
                  implicitHP <|>
@@ -221,6 +223,18 @@ atomicMassP = try $ do
   neg <- negationP
   num <- decimal
   return (AtomicMass neg num)
+
+arylGroupP :: Parser Specification
+arylGroupP = try $ do
+  neg <- negationP
+  _   <- stringP "AG"
+  return (ArylGroup neg)
+
+heteroarylGroupP :: Parser Specification
+heteroarylGroupP = try $ do
+  neg <- negationP
+  _   <- stringP "HG"
+  return (HeteroarylGroup neg)
 
 recursiveP :: Parser Specification
 recursiveP = do

--- a/src/Data/SMARTS/Internal/Types.hs
+++ b/src/Data/SMARTS/Internal/Types.hs
@@ -77,6 +77,8 @@ data Specification = Explicit Negation PrimitiveAtom
                    | ClockwiseCh Negation
                    | ChiralityClass Negation Chirality Presence
                    | AtomicMass Negation Int
+                   | ArylGroup Negation
+                   | HeteroarylGroup Negation
                    | Recursive Negation SMARTS
                    | Class Int
   deriving (Eq, Ord)
@@ -98,6 +100,8 @@ instance Show Specification where
   show (ClockwiseCh neg) = show neg ++ "@@"
   show (ChiralityClass neg chClass pres) = concat [show neg, "@", show chClass, show pres]
   show (AtomicMass neg num) = show neg ++ show num
+  show (ArylGroup neg) = show neg ++ "AG"
+  show (HeteroarylGroup neg) = show neg ++ "HG"
   show (Recursive neg smarts) = concat [show neg, "$(", show smarts, ")"]
   show (Class num) = ':' : show num
 

--- a/src/Data/SMILES/Bond/Parser.hs
+++ b/src/Data/SMILES/Bond/Parser.hs
@@ -1,9 +1,9 @@
 module Data.SMILES.Bond.Parser where
 
-import           Text.Megaparsec
-import           Text.Megaparsec.Text
-
 import           Data.SMILES.Bond
+import           Data.SMILES.ParserTypes (Parser)
+import           Text.Megaparsec
+import           Text.Megaparsec.Char    (char)
 
 bondP :: Parser Bond
 bondP = (AliphaticBond <$> aliphaticBondP) <|>

--- a/src/Data/SMILES/Parser.hs
+++ b/src/Data/SMILES/Parser.hs
@@ -1,12 +1,12 @@
 module Data.SMILES.Parser where
 
-import           Text.Megaparsec
-import           Text.Megaparsec.Lexer
-import           Text.Megaparsec.Text
-
 import           Data.SMILES
 import           Data.SMILES.Atom.Parser
 import           Data.SMILES.Bond.Parser
+import           Data.SMILES.ParserTypes    (Parser)
+import           Text.Megaparsec
+import           Text.Megaparsec.Char       (char, digitChar)
+import           Text.Megaparsec.Char.Lexer (decimal)
 
 smilesP :: Parser SMILES
 smilesP = do atom <- atomPackP
@@ -34,7 +34,7 @@ ringP :: Parser ChainToken
 ringP = do bondMb <- optional bondP
            pcMb <- optional $ char '%'
            i <- case pcMb of
-             Just _  -> fromIntegral <$> integer
+             Just _  -> decimal
              Nothing -> read . pure <$> digitChar
 
            return $ RingClosure bondMb i

--- a/src/Data/SMILES/ParserTypes.hs
+++ b/src/Data/SMILES/ParserTypes.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
+
+module Data.SMILES.ParserTypes (Parser, stringP) where
+
+
+import           Data.Text            (Text, pack, unpack)
+import           Data.Void            (Void)
+import           Text.Megaparsec
+import           Text.Megaparsec.Char (string)
+
+type Parser = Parsec Void Text
+
+stringP :: (Tokens s ~ Text, MonadParsec e s f) => String -> f String
+stringP = fmap unpack . string . pack

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-8.13
+resolver: nightly-2017-09-26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test/Smarts.hs
+++ b/test/Smarts.hs
@@ -53,6 +53,12 @@ doubleBond = BondExpression [BondOr [BondExplicitAnd [BondImplicitAnd [Double Pa
 explNa :: AtomExpression
 explNa = AtomExpression [AtomOr [AtomExplicitAnd [AtomImplicitAnd [Explicit Pass $ Atom "Na"]]]]
 
+explAR :: AtomExpression
+explAR = AtomExpression [AtomOr [AtomExplicitAnd [AtomImplicitAnd [ArylGroup Pass]]]]
+
+explHB :: AtomExpression
+explHB = AtomExpression [AtomOr [AtomExplicitAnd [AtomImplicitAnd [HeteroarylGroup Pass]]]]
+
 innerStructureTests :: Spec
 innerStructureTests = describe "SMARTS is parsed correctly." $ do
   it "C" $ parseSmarts "C" `shouldBe` Just (SMARTS [Linear $ Component [(implBond, Primitive (Atom "C") [])]])
@@ -67,6 +73,12 @@ innerStructureTests = describe "SMARTS is parsed correctly." $ do
                                                                                 (doubleBond, Primitive (Atom "F") [])]])
   it "C[Na]=F" $ parseSmarts "C[Na]=F" `shouldBe` Just (SMARTS [Linear $ Component [(implBond, Primitive (Atom "C") []),
                                                                                     (implBond, Description explNa []),
+                                                                                    (doubleBond, Primitive (Atom "F") [])]])
+  it "C[AG]=F" $ parseSmarts "C[AG]=F" `shouldBe` Just (SMARTS [Linear $ Component [(implBond, Primitive (Atom "C") []),
+                                                                                    (implBond, Description explAR []),
+                                                                                    (doubleBond, Primitive (Atom "F") [])]])
+  it "C[HG]=F" $ parseSmarts "C[HG]=F" `shouldBe` Just (SMARTS [Linear $ Component [(implBond, Primitive (Atom "C") []),
+                                                                                    (implBond, Description explHB []),
                                                                                     (doubleBond, Primitive (Atom "F") [])]])
   it "C1C=CC=CC=1" $ parseSmarts "C1C=CC=CC=1" `shouldBe` Just (SMARTS [Linear $ Component [(implBond, Primitive (Atom "C") [Closure implBond 1]),
                                                                                             (implBond, Primitive (Atom "C") []),


### PR DESCRIPTION
HasChem uses LTS-9.3 which contains new version of Megaparsec. There are major naming and logic changes In this version, so code required update.
Added aryl and heteroeryl groups as atom characteristics, as requested by https://github.com/AlexKaneRUS.